### PR TITLE
uwc/kpi-tactic/build_scripts:Bug Fixes

### DIFF
--- a/build_scripts/03_Build_Run_UWC.sh
+++ b/build_scripts/03_Build_Run_UWC.sh
@@ -83,7 +83,8 @@ function harden()
 	docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 ia_etcd
 	docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 ia_etcd_provision
 	docker ps -q --filter "name=sparkplug-bridge" | grep -q . && docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 sparkplug-bridge
-	docker ps -q --filter "name=kpi-tactic-app" | grep -q . && docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 kpi-tactic-app
+# Increase pid limit for KPI to 500 for processing larger count of threads.
+	docker ps -q --filter "name=kpi-tactic-app" | grep -q . && docker container update --pids-limit=500 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 kpi-tactic-app
 }
 
 function main()

--- a/build_scripts/05_applyConfigChanges.sh
+++ b/build_scripts/05_applyConfigChanges.sh
@@ -54,7 +54,8 @@ function harden()
 	docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 ia_etcd
 	docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 ia_etcd_provision
 	docker ps -q --filter "name=sparkplug-bridge" | grep -q . && docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 sparkplug-bridge
-	docker ps -q --filter "name=kpi-tactic-app" | grep -q . && docker container update --pids-limit=100 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 kpi-tactic-app
+# Increase the pid limit of KPI to 500 to process larger number of threads.
+	docker ps -q --filter "name=kpi-tactic-app" | grep -q . && docker container update --pids-limit=500 --restart=on-failure:5 --cpu-shares 512 -m 1G --memory-swap -1 kpi-tactic-app
 }
 
 export DOCKER_CONTENT_TRUST=1


### PR DESCRIPTION
-Increased pids-limit to 500 for kpi-tactic App
-Creating single thread for Logs analysis message (threadAnalysisMsg) and single thread for write request creation (threadWriteReq) instead of creating multiple threads based on number of control loops

Signed-off-by: anuj.kumar@softdel.com <anuj.kumar@softdel.com>