### PR TITLE
uwc/Sparkplug-bridge : Fix the Sparkplug-bridge disconnection issue with internal MQTT broker

### DIFF
--- a/sparkplug-bridge/SPARKPLUG-BRIDGE/src/SCADAHandler.cpp
+++ b/sparkplug-bridge/SPARKPLUG-BRIDGE/src/SCADAHandler.cpp
@@ -166,7 +166,7 @@ void CSCADAHandler::handleIntMQTTConnLostThread()
 				{
 					break;
 				}
-				DO_LOG_ERROR("INFO: Internal MQTT connection lost. DDEATH to be sent");
+				DO_LOG_ERROR("Internal MQTT connection lost. DDEATH to be sent");
 
 				// Publish DDEATH for each device
 				auto vDevList = CSparkPlugDevManager::getInstance().getDeviceList();

--- a/sparkplug-bridge/docker-compose.yml
+++ b/sparkplug-bridge/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       ETCD_PREFIX: ${ETCD_PREFIX}
       Log4cppPropsFile: "/opt/intel/config/log4cpp.properties"
       DEVICES_GROUP_LIST_FILE_NAME: "Devices_group_list.yml"
-      INTERNAL_MQTT_URL: "${MQTT_PROTOCOL}://127.0.0.1:11883"
+      INTERNAL_MQTT_URL: "${MQTT_PROTOCOL}://mqtt_container:11883"
       NETWORK_TYPE: "ALL"
       TOPIC_SEPARATOR: '-'
       CertType: "zmq"


### PR DESCRIPTION
 uwc/Sparkplug-bridge : Fix the Sparkplug-bridge disconnection issue with internal MQTT broker

    1. Update the end point value to suit network mode host change, hence fixing the Sparkplug-bridge disconnection issue with internal MQTT broker
    2. Updated the log message.

    Signed-off-by: nagdeepgk <nagdeep.gk@intel.com>
