### PR TITLE
uwc/eii_configs : Added back server config to InfluxDBConnector config.json

### DIFF
--- a/eii_configs/InfluxDBConnector.json
+++ b/eii_configs/InfluxDBConnector.json
@@ -15,5 +15,16 @@
         "tag_keys": [],
         "blacklist_query": ["CREATE","DROP","DELETE","ALTER","<script>"]
     },
-    "interfaces": {}
+    "interfaces": {
+        "Servers": [
+            {
+                "Name": "InfluxDBConnector",
+                "Type": "zmq_tcp",
+                "EndPoint": "0.0.0.0:65145",
+                "AllowedClients": [
+                    "*"
+                ]
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Since, InfluxDB Connector's GO code is indexing server[] config, adding the server config is mandatory even though we are not using the server.

    Signed-off-by: nagdeepgk <nagdeep.gk@intel.com>
