### PR TITLE
uwc/mqtt-bridge : Bug fixes for priority thread related stale prints & ROD/WOD bugs

### DIFF
--- a/modbus-master/Modbus-App/include/PublishJson.hpp
+++ b/modbus-master/Modbus-App/include/PublishJson.hpp
@@ -32,17 +32,8 @@
 #define READ_REQ	 	"NRT/read"
 #define READ_REQ_RT 	"RT/read"
 
-// #define READ_RES	"_RdResp"
-// #define READ_RES_RT	"_RdResp_RT"
-
 #define WRITE_REQ 		"NRT/write"
 #define WRITE_REQ_RT 	"RT/write"
-
-// #define WRITE_RES 	"_WrResp"
-// #define WRITE_RES_RT "_WrResp_RT"
-
-// #define POLLDATA	"PolledData"
-// #define POLLDATA_RT	"PolledData_RT"
 
 /**
  * Structure to contain state for a publisher thread

--- a/modbus-master/Modbus-App/src/PublishJson.cpp
+++ b/modbus-master/Modbus-App/src/PublishJson.cpp
@@ -62,36 +62,6 @@ PublishJsonHandler& PublishJsonHandler::instance()
 bool PublishJsonHandler::setTopicForOperation(std::string a_sTopic)
 {
 	bool bRet = true;
-	// if(regExFun(a_sTopic, READ_RES))
-	// {
-	// 	PublishJsonHandler::instance().setSReadResponseTopic(a_sTopic);
-	// 	DO_LOG_INFO("read res topic = " + a_sTopic);
-	// }
-	// else if(regExFun(a_sTopic, READ_RES_RT))
-	// {
-	// 	PublishJsonHandler::instance().setSReadResponseTopicRT(a_sTopic);
-	// 	DO_LOG_INFO("read res RT topic = " + a_sTopic);
-	// }
-	// else if(regExFun(a_sTopic, WRITE_RES))
-	// {
-	// 	PublishJsonHandler::instance().setSWriteResponseTopic(a_sTopic);
-	// 	DO_LOG_INFO("write res topic = " + a_sTopic);
-	// }
-	// else if(regExFun(a_sTopic, WRITE_RES_RT))
-	// {
-	// 	PublishJsonHandler::instance().setSWriteResponseTopicRT(a_sTopic);
-	// 	DO_LOG_INFO("write res RT topic = " + a_sTopic);
-	// }
-	// else if(regExFun(a_sTopic, POLLDATA))
-	// {
-	// 	PublishJsonHandler::instance().setPolledDataTopic(a_sTopic);
-	// 	DO_LOG_INFO("poll topic = " + a_sTopic);
-	// }
-	// else if(regExFun(a_sTopic, POLLDATA_RT))
-	// {
-	// 	PublishJsonHandler::instance().setPolledDataTopicRT(a_sTopic);
-	// 	DO_LOG_INFO("poll topic RT = " + a_sTopic);
-	// }
 	if(regExFun(a_sTopic, READ_REQ) or
 		regExFun(a_sTopic, READ_REQ_RT) or
 		regExFun(a_sTopic, WRITE_REQ) or

--- a/mqtt-bridge/MQTT-Bridge/src/Main.cpp
+++ b/mqtt-bridge/MQTT-Bridge/src/Main.cpp
@@ -47,12 +47,12 @@ std::atomic<bool> g_shouldStop(false);
 // topic syntax -
 // for non-RT topic for polling - <topic_name>__PolledData
 // for RT topic read RT - <topic_name>__RdReq_RT
-#define POLLING			 		"_PolledData"
-#define POLLING_RT 				"_PolledData_RT"
-#define READ_RESPONSE 			"_RdResp"
-#define READ_RESPONSE_RT		"_RdResp_RT"
-#define WRITE_RESPONSE 			"_WrResp"
-#define WRITE_RESPONSE_RT		"_WrResp_RT"
+#define POLLING			 		"NRT/update"
+#define POLLING_RT 				"RT/update"
+#define READ_RESPONSE 			"NRT/writeResponse"
+#define READ_RESPONSE_RT		"RT/readResponse"
+#define WRITE_RESPONSE 			"NRT/writeResponse"
+#define WRITE_RESPONSE_RT		"RT/writeResponse"
 
 /**
  * Process message received from EII and send for publishing on MQTT


### PR DESCRIPTION
1. Removed the stake P thread related prints in mqtt-bridge.
2. Global operations parameter value which was not getting passed to thread is now passed.

Signed-off-by: nagdeepgk <nagdeep.gk@intel.com>